### PR TITLE
Switch Login.java to record

### DIFF
--- a/src/main/java/org/lsc/plugins/connectors/fusiondirectory/FusionDirectoryDao.java
+++ b/src/main/java/org/lsc/plugins/connectors/fusiondirectory/FusionDirectoryDao.java
@@ -135,10 +135,7 @@ public class FusionDirectoryDao {
 	private Token startSession() throws LscServiceException {
 		Response response = null;
 		try {
-			Login login = new Login();
-			login.setUser(username);
-			login.setPassword(password);
-			login.setDirectory(directory);
+			Login login = new Login(username, password, directory);
 			WebTarget currentTarget = target.path("login");
 			LOGGER.info(String.format("Login to FusionDirectory %s as %s for thread %s ... ",
 					currentTarget.getUri().toString(), username, Thread.currentThread().threadId()));

--- a/src/main/java/org/lsc/plugins/connectors/fusiondirectory/beans/Login.java
+++ b/src/main/java/org/lsc/plugins/connectors/fusiondirectory/beans/Login.java
@@ -42,29 +42,11 @@
  */
 package org.lsc.plugins.connectors.fusiondirectory.beans;
 
-public class Login {
-	private String user;
-	private String password;
-	private String directory;
-	
-	public String getUser() {
-		return user;
-	}
-	public void setUser(String user) {
-		this.user = user;
-	}
-	public String getPassword() {
-		return password;
-	}
-	public void setPassword(String password) {
-		this.password = password;
-	}
-	public String getDirectory() {
-		return directory;
-	}
-	public void setDirectory(String directory) {
-		this.directory = directory;
-	}
-	
-	
+import java.util.Objects;
+
+public record Login(String user, String password, String directory) {
+    public Login {
+        Objects.requireNonNull(user, "user must not be null");
+        Objects.requireNonNull(password, "password must not be null");
+    }
 }


### PR DESCRIPTION
Convert `Login` from a mutable class with getters/setters to an immutable Java record with constructor validation, and simplify its instantiation in `startSession()`.