### PR TITLE
Refactor type checks to use pattern matching

### DIFF
--- a/src/main/java/org/lsc/plugins/connectors/fusiondirectory/FusionDirectoryAbstractService.java
+++ b/src/main/java/org/lsc/plugins/connectors/fusiondirectory/FusionDirectoryAbstractService.java
@@ -160,8 +160,7 @@ public abstract class FusionDirectoryAbstractService implements IService {
 		Map<String, Map<String, Object>> attrs = new HashMap<String, Map<String, Object>>();
 		for (String attribute : modificationsItemsByHash.keySet()) {
 			TabAttribute tabAttribute = getTabAttribute(attribute);
-			if (modificationsItemsByHash.get(attribute) instanceof ArrayList<?>) {
-				ArrayList<?> list = (ArrayList<?>) modificationsItemsByHash.get(attribute);
+			if (modificationsItemsByHash.get(attribute) instanceof ArrayList<?> list) {
 				if (!list.isEmpty() || tabAttribute.getAttribute().isMultiple() || tabAttribute.isOption()) {
 					if (attrs.get(tabAttribute.getTab()) == null) {
 						attrs.put(tabAttribute.getTab(), new HashMap<String, Object>());
@@ -195,8 +194,8 @@ public abstract class FusionDirectoryAbstractService implements IService {
 		List<String> toDelete = new ArrayList<>();
 		for (String attribute : modificationsItemsByHash.keySet()) {
 			TabAttribute tabAttribute = getTabAttribute(attribute);
-			if (modificationsItemsByHash.get(attribute) instanceof ArrayList<?>) {
-				if (((ArrayList<?>) modificationsItemsByHash.get(attribute)).isEmpty()
+			if (modificationsItemsByHash.get(attribute) instanceof ArrayList<?> list) {
+				if (list.isEmpty()
 						&& !tabAttribute.getAttribute().isMultiple() && !tabAttribute.isOption()) {
 					toDelete.add(tabAttribute.getTab() + "/" + tabAttribute.getAttribute().getValue());
 				}
@@ -266,10 +265,10 @@ public abstract class FusionDirectoryAbstractService implements IService {
 			if (mopt.matches()) {
 				String option = mopt.group(2);
 				if (currentValues != null) {
-					if (currentValues instanceof String) {
-						newValues.add((String) currentValues);
-					} else if (currentValues instanceof List<?>) {
-						newValues.addAll((List<? extends String>) currentValues);
+					if (currentValues instanceof String s) {
+						newValues.add(s);
+					} else if (currentValues instanceof List<?> list) {
+						newValues.addAll((List<? extends String>) list);
 					}
 				}
 				for (Object value : list) {

--- a/src/main/java/org/lsc/plugins/connectors/fusiondirectory/FusionDirectoryDao.java
+++ b/src/main/java/org/lsc/plugins/connectors/fusiondirectory/FusionDirectoryDao.java
@@ -373,12 +373,12 @@ public class FusionDirectoryDao {
 								throw new LscServiceException(String.format("Attribute %s could not be found in tab %s", attribute.getValue(), attributesTab.getName()));
 							}
 							// Empty string value are considered unset
-							if (value instanceof String && ((String)value).isEmpty()) {
+							if (value instanceof String s && s.isEmpty()) {
 								continue;
 							}
 							// LscBean does not accept Long object
-							if (value instanceof Long) {
-								value = ((Long)value).toString();
+							if (value instanceof Long l) {
+								value = l.toString();
 							}
 							results.put(attribute.getValue(), value);
 						}
@@ -413,11 +413,11 @@ public class FusionDirectoryDao {
 		List<String> values = new ArrayList<String>();
 		if (mopt.matches()) {
 			String option = mopt.group(2);
-			if (rawValues instanceof String
-					&& ((String) rawValues).toLowerCase().startsWith(option.toLowerCase() + ";")) {
-				values.add(((String) rawValues).replaceAll("(?i)" + option + ";", ""));
-			} else if (rawValues instanceof List<?>) {
-				for (Object rawValue : (List<Object>) rawValues) {
+			if (rawValues instanceof String s
+					&& (s.toLowerCase().startsWith(option.toLowerCase() + ";")) {
+				values.add(s.replaceAll("(?i)" + option + ";", ""));
+			} else if (rawValues instanceof List<?> list) {
+				for (Object rawValue : list) {
 					if (((String) rawValue).toLowerCase().startsWith(option.toLowerCase() + ";")) {
 						values.add(((String) rawValue).replaceAll("(?i)" + option + ";", ""));
 					}


### PR DESCRIPTION
Replace `instanceof` checks with Java 16+ pattern matching across `FusionDirectoryAbstractService` and `FusionDirectoryDao`